### PR TITLE
Add daily workflows

### DIFF
--- a/.github/workflows/daily-db-backup.yml
+++ b/.github/workflows/daily-db-backup.yml
@@ -1,0 +1,36 @@
+name: Daily DB Backup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wake up Render
+        run: curl -I https://nauticatest.app/api/health
+      - name: Wait for service
+        run: sleep 60
+      - name: Trigger backup
+        id: trigger
+        run: |
+          response=$(curl -s -w "%{http_code}" -X POST "https://nauticatest.app/api/run-backup?token=${{ secrets.BACKUP_TOKEN }}")
+          status="${response: -3}"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "${response::-3}" > backup-response.txt
+      - name: Check result
+        run: |
+          if [ "${{ steps.trigger.outputs.status }}" != "200" ]; then
+            echo "Backup failed" >&2
+            cat backup-response.txt >&2
+            exit 1
+          fi
+          echo "Backup completed successfully" >> "$GITHUB_STEP_SUMMARY"
+          cat backup-response.txt >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload response log
+        uses: actions/upload-artifact@v4
+        with:
+          name: backup-response
+          path: backup-response.txt

--- a/.github/workflows/daily-reminders.yml
+++ b/.github/workflows/daily-reminders.yml
@@ -1,0 +1,20 @@
+name: Daily reminders
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * *'
+
+jobs:
+  send-reminders:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wake up Render
+        run: curl -I https://nauticatest.app/api/health
+
+      - name: Wait for service
+        run: sleep 60
+
+      - name: Trigger reminder job
+        run: curl -X POST "https://nauticatest.app/api/run-reminders?token=${{ secrets.REMINDER_TOKEN }}"

--- a/.github/workflows/ping-main.yml
+++ b/.github/workflows/ping-main.yml
@@ -1,0 +1,12 @@
+name: Ping main site
+
+on:
+  schedule:
+    - cron: '*/1 * * * *'
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping root endpoint
+        run: curl -I https://nauticatest.app/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Project Notes
+
+This repository stores GitHub Actions used to automate daily tasks for the Nautica application.  The workflows live under `.github/workflows`.
+
+Workflows included:
+- `daily-reminders.yml` triggers reminder jobs each day at 16:00 UTC and can be run manually.
+- `daily-db-backup.yml` runs the database backup every day at 02:00 UTC and uploads the response log.
+- `ping-main.yml` pings the main website every minute to keep the service awake.
+
+Local development with `pnpm dev` will fail because the MongoDB server is not available in this environment, so do not attempt to run it here.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-"# Actions" 
+# Actions
+
+This repository contains GitHub Actions workflows for the Nautica application. They reside in `.github/workflows` and handle daily reminders, daily database backups and a continuous ping to keep the service awake.


### PR DESCRIPTION
## Summary
- add daily reminders workflow
- add daily DB backup workflow
- add minute ping workflow
- document the workflows and repo structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ceda5583c8328a6008186ca560895