### PR TITLE
Add daily report workflow

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -1,0 +1,17 @@
+name: Daily report
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 16 * * *'
+
+jobs:
+  send-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wake up Render
+        run: curl -I https://nauticatest.app/api/health
+      - name: Wait for service
+        run: sleep 60
+      - name: Trigger daily report
+        run: curl -X POST "https://nauticatest.app/api/run-daily-report?token=${{ secrets.DAILY_REPORT_TOKEN }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repository stores GitHub Actions used to automate daily tasks for the Nauti
 
 Workflows included:
 - `daily-reminders.yml` triggers reminder jobs each day at 16:00 UTC and can be run manually.
+- `daily-report.yml` runs the daily report each day at 16:15 UTC and can be triggered manually.
 - `daily-db-backup.yml` runs the database backup every day at 02:00 UTC and uploads the response log.
 - `ping-main.yml` pings the main website every minute to keep the service awake.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Actions
 
-This repository contains GitHub Actions workflows for the Nautica application. They reside in `.github/workflows` and handle daily reminders, daily database backups and a continuous ping to keep the service awake.
+This repository contains GitHub Actions workflows for the Nautica application. They reside in `.github/workflows` and handle daily reminders, daily reports, daily database backups and a continuous ping to keep the service awake.


### PR DESCRIPTION
## Summary
- add a workflow to trigger the daily report
- document the new workflow
- list the new workflow in AGENTS notes

## Testing
- `pnpm -v`

------
https://chatgpt.com/codex/tasks/task_e_687cf733bd4c8328b545b1dda932808d